### PR TITLE
wrap node names in quotation marks

### DIFF
--- a/lib/src/viz_package.dart
+++ b/lib/src/viz_package.dart
@@ -117,7 +117,7 @@ class VizPackage extends Comparable {
       props['xlabel'] = '"$latestVersion"';
     }
 
-    _writeNode(sink, name, props);
+    _writeNode(sink, '"$name"', props);
 
     var orderedDeps = dependencies.toList(growable: false)..sort();
 
@@ -181,7 +181,7 @@ void _writeNode(StringSink sink, String name, Map<String, String> values) {
 
 void _writeEdge(
     StringSink sink, String from, String to, Map<String, String> values) {
-  var name = '$from -> $to';
+  var name = '"$from" -> "$to"';
   _writeNode(sink, name, values);
 }
 


### PR DESCRIPTION
I ran into an issue with some of my projects.  It turns out that packages that include dashes cause the error shown below.

```
abort() at Error
    at Error (native)
    at bb (http://kevmoo.github.io/pubviz/viz.js:9:172)
    at aa (http://kevmoo.github.io/pubviz/viz.js:34:259)
    at Array.GG (http://kevmoo.github.io/pubviz/viz.js:1245:30917)
    at sx (http://kevmoo.github.io/pubviz/viz.js:1237:24178)
    at Wx (http://kevmoo.github.io/pubviz/viz.js:1237:36967)
    at IA (http://kevmoo.github.io/pubviz/viz.js:1209:36701)
    at Pz (http://kevmoo.github.io/pubviz/viz.js:1209:14637)
    at ld (http://kevmoo.github.io/pubviz/viz.js:1201:850)
    at qb (http://kevmoo.github.io/pubviz/viz.js:3:8)
```

Wrapping the node names in quotation marks fixes this.