### PR TITLE
Run pub in shell

### DIFF
--- a/lib/src/viz_root.dart
+++ b/lib/src/viz_root.dart
@@ -105,7 +105,7 @@ class VizRoot {
 Future<Map<String, String>> _getPackageMap(String path) async {
   var map = new Map<String, String>();
 
-  var result = await Process.run('pub', ['list-package-dirs']);
+  var result = await Process.run('pub', ['list-package-dirs'], runInShell: true);
   var json = JSON.decode(result.stdout as String);
 
   var packages = json['packages'] as Map;


### PR DESCRIPTION
On Windows, pub is a batch file and doesn't work if you don't use runInShell. Then you just get a file not found error.