### PR TITLE
Added archive functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .packages
 .pub
 pubspec.lock
+pubviz/*

--- a/README.md
+++ b/README.md
@@ -79,8 +79,9 @@ $ pubviz -?
 Usage: pubviz [<args>] <command> [<package path>]
 
 Commands:
-  open   Populate a temporary file with the content and open it.
-  print  Print the output to stdout.
+  open     Populate a temporary file with the content and open it.
+  print    Print the output to stdout.
+  archive  Generates an HTML report in the current directory, under pubviz/index.html.
 
 Arguments:
   -f, --format=<format>

--- a/bin/pubviz.dart
+++ b/bin/pubviz.dart
@@ -51,7 +51,7 @@ void main(List<String> args) async {
     } else if (command.name == 'open') {
       await _open(vp, options.format, options.ignorePackages);
     } else if (command.name == 'archive') {
-      await _generate(vp, options.format, options.ignorePackages);
+      await _archive(vp, options.format, options.ignorePackages);
     } else {
       throw StateError('Should never get here...');
     }
@@ -119,7 +119,7 @@ void _printContent(
   print(content);
 }
 
-Future _generate(
+Future _archive(
     VizRoot root, FormatOptions format, List<String> ignorePackages) {
   final dir = Directory('pubviz');
   final fileName = 'index.html';

--- a/test/cli_test.dart
+++ b/test/cli_test.dart
@@ -28,7 +28,7 @@ $_usage''');
     final proc = await TestProcess.start('dart', ['bin/pubviz.dart']);
 
     final output = await proc.stdoutStream().join('\n');
-    expect(output, '''Specify a command: open, print
+    expect(output, '''Specify a command: open, print, archive
 
 $_usage''');
 
@@ -46,8 +46,9 @@ $_usage''');
 const _usage = r'''Usage: pubviz [<args>] <command> [<package path>]
 
 Commands:
-  open   Populate a temporary file with the content and open it.
-  print  Print the output to stdout.
+  open     Populate a temporary file with the content and open it.
+  print    Print the output to stdout.
+  archive  Generates an HTML report in the current directory, under pubviz/index.html.
 
 Arguments:
   -f, --format=<format>


### PR DESCRIPTION
The `archive` command will generate an HTML report under pubviz/index.html.
This will help devs and CI/CD environments to have access to the report, rather than the temp file generated with `open`.

This should address #23 